### PR TITLE
Reduced range of truth check on prolog output to prevent false positives

### DIFF
--- a/humor_analyzer.py
+++ b/humor_analyzer.py
@@ -75,7 +75,7 @@ class App(QMainWindow):
 
         answer = 'False'
         # uses regex to see if true was returned by swipl
-        if re.search('true', response[0]):
+        if re.search('true', response[0][-10:]):
             answer = 'True'
 
         print(question + '    ' + answer)


### PR DESCRIPTION
I'm not sure if you want to accept the change, but this will make it so if "true" is included in the query, it will no longer automatically pass.

The resulting string is now only checked at the very end where the answer is located as true or false.